### PR TITLE
Sign.up.fix2

### DIFF
--- a/src/css/sign-up.css
+++ b/src/css/sign-up.css
@@ -202,6 +202,7 @@
     height: 119px;
     resize: none;
     opacity: 0.7;
+    outline: none;
   }
 
   .sign-up-message::placeholder {

--- a/src/css/sign-up.css
+++ b/src/css/sign-up.css
@@ -123,6 +123,7 @@
 @media screen and (min-width: 375px) {
   .private-policy {
     width: 335px;
+    letter-spacing: -0.01rem;
   }
 
   .img-wrap {

--- a/src/partials/sign-up.html
+++ b/src/partials/sign-up.html
@@ -35,10 +35,11 @@
       <button type="submit" class="sign-up-btn">Send</button>
 
       <p class="private-policy">
-        By clicking on &#10077;Send&#10078; button, you agree to our
+        By clicking on &#8243;Send&#8243; button, you agree to our
         <a href="https://example.com/privacy-policy" class="private-policy-link"
           >Privacy Policy</a
-        >, and allow Promodo to use this information for marketing purposes.
+        >,<br />and allow Promodo to use this information for marketing
+        purposes.
       </p>
     </form>
     <div class="img-wrap">


### PR DESCRIPTION
зміна знаку лапок для слова send, вони були жирні не по макету. Знайшов подібні, хоча б не так кидаються в очі. Зробив перенос тексту після Privacy Policy, для десктопу та таблету, щоправда на мобайлі у першу строку не влазить Privacy Policy. Якщо до прикладу у @media screen and (min-width: 375px) добавити letter-spacing: -0.01rem; буде все ок.
